### PR TITLE
Restaurar selección de imágenes en iOS

### DIFF
--- a/Auto-Image.js
+++ b/Auto-Image.js
@@ -2218,7 +2218,8 @@
         const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
         if (isMobile) {
           input.accept += ",image/*"
-          input.capture = "environment" // Use rear camera by default
+          // Removed input.capture to allow multiple options (Files, Camera, Photos) on iOS
+          // Setting capture would force camera-only mode
         }
         
         // Add timeout for mobile compatibility


### PR DESCRIPTION
Remove `input.capture` attribute to restore multiple image upload options on iOS.

---
<a href="https://cursor.com/background-agent?bcId=bc-020d9d3a-77c8-46dd-b825-7d3c12ced107">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-020d9d3a-77c8-46dd-b825-7d3c12ced107">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

